### PR TITLE
Init Terraform code for managing AWS SSO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# For local testing
+.env
+.secrets

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,48 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.76.0"
+  constraints = ">= 4.35.0, ~> 5.1"
+  hashes = [
+    "h1:JSLR3JP9naVcnH0PHcDwwHr3aQB9vlW0+b8HQma1GpU=",
+    "zh:05b2a0d25fc07576f6698d4840d0d2ae2599484c49f1b911ea1154584557bc13",
+    "zh:1b22dd1d9c482739e133adb996a9c8b285ca7d978d0fe04deaa5588eba5d254c",
+    "zh:216088c8800e7b8d7eff7b1a822317bc6faec64f27946ffd22bb3494ac4175cb",
+    "zh:43e994112b1484bf49945c4885aa2fee32486c9a5d64b9146bbd6f309f24e332",
+    "zh:46a28ba800f176eef500f998217bccc331605ef05f11abb1728f727a81f3a8b0",
+    "zh:4fad2743174a600da76a0cceeec2fef8399a18d880ba8929d811cd5cea1b5dee",
+    "zh:5c42a2c1438cd7533456026f52b562715664490711fdea809f44610a7565c145",
+    "zh:792d4fd4be434682e4540d2579505c7f11f39d0efe1d12ee2761ed0d46c8cd51",
+    "zh:7bb5f9f87c9da6d62d6f89504f01a9d6d2f19dcaa0efc46ea51ebdc4bb6fd536",
+    "zh:81cdbd97f81b1110fce793944d5668a4389904979eb7d178d3142a6b0e175e5e",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ab4b881eb0f3812b702aaecf921c5c16bbcc33d61d668be4d72d6da9c57ded85",
+    "zh:c1d9d1166fd948845614deef81f3197568d0d3c2a03b8b97fff308ebc59043f9",
+    "zh:cda7530f2c01434e483d3faf62fc0685295e7f844176aa38df1ba65fa6a4407a",
+    "zh:fdad558b1c41aa68123d0da82cc0d65bc86d09eaa1ab1d3a167ec3bce0fc0c66",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/awscc" {
+  version     = "1.20.0"
+  constraints = ">= 0.55.0"
+  hashes = [
+    "h1:PkRJD0qrda/+mFdmVTC1fhMhUMY/Vp57giG+grQ5Dvk=",
+    "zh:06cfe1b144a81b673e24cc0479ca1d0adea55353d77bcd4f5e63215bb5d7fd98",
+    "zh:0d41cc4c02e5b7e8936434c6a8c54140e4fb1f766455ffec65a8e397f834c5e7",
+    "zh:0d67579f4bc04b14f17a4a5a63ba1562ed6ba5e53bfdf31c7d1d4cae8965d26d",
+    "zh:162e38011e9e353a4743a1d3a211fef2c1cf70ab2ce3f3731d0d066b8a5c0f16",
+    "zh:22488d0a05981eed62bec54447bd9f6047623a7d88c720ad1430e7cb7b7b9861",
+    "zh:3e66d09e6a4dbdcdc08ac9f11ab1e563c16bcf2dfc3daa40e03b3aac9b7cd822",
+    "zh:47d26356b61d23fb70180487c5227497c3f0fab111d04803a30465850f197031",
+    "zh:50d906fb53a9b52f5097ce1635b30843057a6b86170d29d61197bac7b1d7f84f",
+    "zh:7f144e5d07724a7b5b717ce034abe52651f1f7c6d60c9e87a9be3bbc43ea5f08",
+    "zh:9502d3929793afe8794798fdc7bc070e41fc1328ec6eb331f4f00b2f08895988",
+    "zh:956ed0d78ccb670de2f6cfa66bf455b4da77f59f8d7db7d905b5f7bbaff1346c",
+    "zh:96b9d91fa06b30004ba3f6fca1c7d6c850ecf8ea72f4b231e772ae17ed1a6dfa",
+    "zh:aea81a2708cf8436ad66aa28cb4bfa289fdd8d1f61ea35b21877e4be4b7bd0ed",
+    "zh:c10e7dd7453761d869b888b3b0a472d89fa3d74de2444e606683e472e0953e06",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,13 @@ terraform {
 
 provider "aws" {
   region = var.location
+  default_tags {
+    tags = {
+      Project    = "inff"
+      ManagedBy  = "Terraform"
+      Principal  = var.create_by
+    }
+  }
 }
 
 # Use Identity Center Module
@@ -36,7 +43,7 @@ module "aws-iam-identity-center" {
 
   # Create desired USERS in IAM Identity Center
   sso_users = {
-    "yc.wang" : {
+    "ycwang0037" : {
       group_membership = ["DevOps"]              # Management Groups
       user_name        = "ycwang0037"            # Unique username, <given-name><surname><4-digit-number>
       given_name       = "Yuechen"               # Your given name
@@ -74,7 +81,7 @@ module "aws-iam-identity-center" {
       principal_name  = "Admin"                                   # name of the user or group you wish to have access to the account(s)
       principal_type  = "GROUP"                                   # principal type (user or group) you wish to have access to the account(s)
       principal_idp   = "INTERNAL"                                # type of Identity Provider you are using. Valid values are "INTERNAL" (using Identity Store) or "EXTERNAL" (using external IdP such as EntraID, Okta, Google, etc.)
-      permission_sets = ["AdministratorAccess", "ViewOnlyAccess"] # permissions the user/group will have in the account(s)
+      permission_sets = ["AdministratorAccess"] # permissions the user/group will have in the account(s)
       account_ids     = [var.prod_account]                        # account(s) the group will have access to. Permissions they will have in account are above line
     },
     DevOps : {

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,96 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.1"
+    }
+  }
+
+  # Backend Skeleton
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = var.location
+}
+
+# Use Identity Center Module
+module "aws-iam-identity-center" {
+  source = "aws-ia/iam-identity-center/aws"
+
+  # Create desired GROUPS in IAM Identity Center
+  sso_groups = {
+    Admin : {
+      group_name        = "Admin"
+      group_description = "Admin IAM Identity Center Group"
+    },
+    DevOps : {
+      group_name        = "DevOps"
+      group_description = "DevOps IAM Identity Center Group"
+    },
+    Dev : {
+      group_name        = "Dev"
+      group_description = "Dev IAM Identity Center Group"
+    },
+  }
+
+  # Create desired USERS in IAM Identity Center
+  sso_users = {
+    "yc.wang" : {
+      group_membership = ["DevOps"]              # Management Groups
+      user_name        = "ycwang0037"            # Unique username, <given-name><surname><4-digit-number>
+      given_name       = "Yuechen"               # Your given name
+      family_name      = "Wang"                  # Your family name
+      email            = "ycyc-doit@outlook.com" # Your working email
+    },
+    # Add your account details above, assign proper membership and create PR. DO NOT delete this comment
+  }
+
+  # Create permissions sets backed by AWS managed policies
+  permission_sets = {
+    AdministratorAccess = {
+      description          = "Provides AWS full access permissions.",
+      session_duration     = "PT1H", // how long until session expires - this means 1 hours. max is 12 hours
+      aws_managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+      tags                 = { ManagedBy = "Terraform" }
+    },
+    PowerUserAccess = {
+      description          = "Provides AWS full access permissions, but does not allow management of Users and groups.",
+      session_duration     = "PT2H", // how long until session expires - this means 2 hours. max is 12 hours
+      aws_managed_policies = ["arn:aws:iam::aws:policy/PowerUserAccess"]
+      tags                 = { ManagedBy = "Terraform" }
+    },
+    ReadOnlyAccess = {
+      description          = "Provides AWS read only permissions.",
+      session_duration     = "PT4H", // how long until session expires - this means 4 hours. max is 12 hours
+      aws_managed_policies = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+      tags                 = { ManagedBy = "Terraform" }
+    },
+  }
+
+  # Assign users/groups access to accounts with the specified permissions
+  account_assignments = {
+    Admin : {
+      principal_name  = "Admin"                                   # name of the user or group you wish to have access to the account(s)
+      principal_type  = "GROUP"                                   # principal type (user or group) you wish to have access to the account(s)
+      principal_idp   = "INTERNAL"                                # type of Identity Provider you are using. Valid values are "INTERNAL" (using Identity Store) or "EXTERNAL" (using external IdP such as EntraID, Okta, Google, etc.)
+      permission_sets = ["AdministratorAccess", "ViewOnlyAccess"] # permissions the user/group will have in the account(s)
+      account_ids     = [var.prod_account]                        # account(s) the group will have access to. Permissions they will have in account are above line
+    },
+    DevOps : {
+      principal_name  = "DevOps"
+      principal_type  = "GROUP"
+      principal_idp   = "INTERNAL"
+      permission_sets = ["PowerUserAccess"]
+      account_ids     = [var.prod_account]
+    },
+    Dev : {
+      principal_name  = "Dev"
+      principal_type  = "GROUP"
+      principal_idp   = "INTERNAL"
+      permission_sets = ["ReadOnlyAccess"]
+      account_ids     = [var.prod_account]
+    },
+  }
+
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,11 @@
+variable "location" {
+  type = string
+}
+
+variable "prod_account" {
+  type = string
+}
+
+variable "dev_account" {
+  type = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,6 @@
 variable "location" {
   type = string
+  default = "us-east-1"
 }
 
 variable "prod_account" {
@@ -8,4 +9,9 @@ variable "prod_account" {
 
 variable "dev_account" {
   type = string
+}
+
+variable "create_by" {
+  type = string
+  default = "DevOps"
 }


### PR DESCRIPTION
# Summary
The initialisation of access-contorl with AWS identity Center(SSO). This PR does not contain the workflow setup, that will be implemented later on.

---
# Details
The code depends on tf module [terraform-aws-iam-identity-center](https://github.com/aws-ia/terraform-aws-iam-identity-center)
- **Manage groups in identity centre**
- **Manage users in identity centre**
  - This will allow users(devs) to add their details in terraform code and raise PR for approval
- **Manage permission sets in identity centre**
  - Assign permission set to groups

# Testing
I have tested terraform code locally, see identity centre resources with tag {ManagedBy: Terraform}. I will destroy them once we are ok with the result and let github action to run the terraform apply with backend managed in s3 bucket
- **user provision** ✔
- **group provision** ✔
- **permission set provision** ✔
  - permission assignment ❓ yet to be verified