### PR TITLE
feat: workflow init for access control

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -46,7 +46,6 @@ jobs:
 
       - id: get_pr_number
         name: Get PR number
-        if: github.event_name == 'push'
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "Getting PR number based on head_commit"

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,77 @@
+name: Terraform Apply
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: The Pull Request number
+        required: true
+        type: number
+
+
+permissions:
+  id-token: write # This is required for requesting the JWT (OIDC)
+  contents: read
+  pull-requests: write
+
+jobs:
+  terraform_plan:
+    runs-on: ubuntu-22.04
+    steps:
+      - id: checkout_latest
+        name: Checkout latest
+        uses: actions/checkout@v4
+      - id: checkout_common_action
+        name: Checkout latest
+        uses: actions/checkout@v4
+        with:
+          repository: Innovate-Future-Foundation/terraform-bootstrap
+          path: common
+      - id: tf_prep
+        name: Terraform setup using Access Key
+        uses: ./common/actions/setup_with_oidc
+        env:
+          terraform_version: "1.1.7"
+          terraform_dir: "./"
+          aws_tfstate_key: "state/terraform-state"
+        with:
+          terraform_dir: ${{ env.terraform_dir }}
+          terraform_version: ${{ env.terraform_version }}
+          aws_region: ${{ secrets.TF_BACKEND_REGION }}
+          aws_role_arn: ${{ secrets.WF_ROLE_ARN }}
+          aws_tfstate_bucket: ${{ secrets.TF_BACKEND_BUCKET }}
+          aws_tfstate_key: ${{ env.aws_tfstate_key }}
+          aws_tflock_table: ${{ secrets.TF_BACKEND_TABLE }}
+
+      - id: get_pr_number
+        name: Get PR number
+        if: github.event_name == 'push'
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "Getting PR number based on head_commit"
+            PR_NUMBER=$(gh pr list --base main --state merged --search "${{ github.event.head_commit.message }}" --json number --jq '.[0].number')
+          else
+            echo "Getting PR number from dispatch input"
+            PR_NUMBER=${{ github.event.inputs.pr_number }}
+          fi
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No matching PR found"
+            exit 1
+          fi
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - id: dl_tf_plan
+        name: Download Plan from S3
+        run: |
+          aws s3 cp s3://${{ secrets.WF_ARTIFACT_BUCKET }}/plans/plan-pr_${{ steps.get_pr_number.outputs.PR_NUMBER }} tfplan
+          if [ $? -ne 0 ]; then
+            echo "Failed to retrieve planfile. It may have expired or been deleted."
+            exit 1
+          fi
+
+      - id: tf_apply
+        name: Terraform Apply
+        run: terraform apply -auto-approve tfplan

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -16,7 +16,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  terraform_plan:
+  terraform_apply:
     runs-on: ubuntu-22.04
     steps:
       - id: checkout_latest

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -32,7 +32,7 @@ jobs:
         name: Terraform setup using Access Key
         uses: ./common/actions/setup_with_oidc
         env:
-          terraform_version: "1.1.7"
+          terraform_version: "1.10.2"
           terraform_dir: "./"
           aws_tfstate_key: "state/terraform-state"
         with:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -25,7 +25,7 @@ jobs:
           path: common
 
       - id: tf_prep
-        name: Terraform setup using Access Key
+        name: Terraform setup using oidc role
         uses: ./common/actions/setup_with_oidc
         env:
           terraform_version: "1.1.7"
@@ -51,6 +51,8 @@ jobs:
         run: terraform plan -out .planfile
         env:
           TF_VAR_create_by: ${{ steps.get_identity.outputs.identity }}
+          TF_VAR_uat_account: ${{ secrets.ACCOUNT_UAT }}
+          TF_VAR_prod_account: ${{ secrets.ACCOUNT_PROD }}
 
       - id: post_comment
         name: Post Terraform Plan to PR

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,6 +1,10 @@
 name: Terraform Plan
 on:
   pull_request:
+    paths:
+      - '**.tf'
+      - '**.tfvars'
+      - '.github/workflows/terraform-plan.yml'
 
 permissions:
   id-token: write # This is required for requesting the JWT (OIDC)

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,65 @@
+name: Terraform Plan
+on:
+  pull_request:
+
+permissions:
+  id-token: write # This is required for requesting the JWT (OIDC)
+  contents: read
+  pull-requests: write
+
+jobs:
+  terraform_plan:
+    runs-on: ubuntu-22.04
+    # Specify trigger condition
+    if: github.event.pull_request.state != 'approved'
+    steps:
+      - id: checkout_latest
+        name: Checkout latest
+        uses: actions/checkout@v4
+
+      - id: checkout_common_action
+        name: Checkout latest
+        uses: actions/checkout@v4
+        with:
+          repository: Innovate-Future-Foundation/terraform-bootstrap
+          path: common
+
+      - id: tf_prep
+        name: Terraform setup using Access Key
+        uses: ./common/actions/setup_with_oidc
+        env:
+          terraform_version: "1.1.7"
+          terraform_dir: "./"
+          aws_tfstate_key: "state/terraform-state"
+        with:
+          terraform_dir: ${{ env.terraform_dir }}
+          terraform_version: ${{ env.terraform_version }}
+          aws_region: ${{ secrets.TF_BACKEND_REGION }}
+          aws_role_arn: ${{ secrets.WF_ROLE_ARN }}
+          aws_tfstate_bucket: ${{ secrets.TF_BACKEND_BUCKET }}
+          aws_tfstate_key: ${{ env.aws_tfstate_key }}
+          aws_tflock_table: ${{ secrets.TF_BACKEND_TABLE }}
+      
+      - id: get_identity
+        name: Get and check current identity
+        run: |
+          arn=$(aws sts get-caller-identity --query 'Arn' --output text)
+          echo "identity=$(echo $arn | cut -d ':' -f 6)" >> $GITHUB_OUTPUT
+
+      - id: tf_plan
+        name: Terraform Plan
+        run: terraform plan -out .planfile
+        env:
+          TF_VAR_create_by: ${{ steps.get_identity.outputs.identity }}
+
+      - id: post_comment
+        name: Post Terraform Plan to PR
+        uses: borchero/terraform-plan-comment@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          planfile: .planfile
+      
+      - name: Upload Plan to S3
+        run: |
+          aws s3 cp .planfile s3://${{ secrets.WF_ARTIFACT_BUCKET }}/plans/plan-pr_${{ github.event.pull_request.number }}
+          echo "Plan uploaded to S3"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -32,7 +32,7 @@ jobs:
         name: Terraform setup using oidc role
         uses: ./common/actions/setup_with_oidc
         env:
-          terraform_version: "1.1.7"
+          terraform_version: "1.10.2"
           terraform_dir: "./"
           aws_tfstate_key: "state/terraform-state"
         with:

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ provider "aws" {
 # Use Identity Center Module
 module "aws-iam-identity-center" {
   source = "aws-ia/iam-identity-center/aws"
+  version = "1.0.1"
 
   # Create desired GROUPS in IAM Identity Center
   sso_groups = {

--- a/main.tf
+++ b/main.tf
@@ -14,9 +14,9 @@ provider "aws" {
   region = var.location
   default_tags {
     tags = {
-      Project    = "inff"
-      ManagedBy  = "Terraform"
-      Principal  = var.create_by
+      Project   = "inff"
+      ManagedBy = "Terraform"
+      Principal = var.create_by
     }
   }
 }
@@ -27,9 +27,9 @@ module "aws-iam-identity-center" {
 
   # Create desired GROUPS in IAM Identity Center
   sso_groups = {
-    Admin : {
-      group_name        = "Admin"
-      group_description = "Admin IAM Identity Center Group"
+    DevOpsLead : {
+      group_name        = "DevOpsLead"
+      group_description = "DevOpsLead IAM Identity Center Group"
     },
     DevOps : {
       group_name        = "DevOps"
@@ -44,7 +44,7 @@ module "aws-iam-identity-center" {
   # Create desired USERS in IAM Identity Center
   sso_users = {
     "ycwang0037" : {
-      group_membership = ["DevOps"]              # Management Groups
+      group_membership = ["DevOpsLead"]              # Management Groups
       user_name        = "ycwang0037"            # Unique username, <given-name><surname><4-digit-number>
       given_name       = "Yuechen"               # Your given name
       family_name      = "Wang"                  # Your family name
@@ -77,26 +77,26 @@ module "aws-iam-identity-center" {
 
   # Assign users/groups access to accounts with the specified permissions
   account_assignments = {
-    Admin : {
-      principal_name  = "Admin"                                   # name of the user or group you wish to have access to the account(s)
-      principal_type  = "GROUP"                                   # principal type (user or group) you wish to have access to the account(s)
-      principal_idp   = "INTERNAL"                                # type of Identity Provider you are using. Valid values are "INTERNAL" (using Identity Store) or "EXTERNAL" (using external IdP such as EntraID, Okta, Google, etc.)
-      permission_sets = ["AdministratorAccess"] # permissions the user/group will have in the account(s)
-      account_ids     = [var.prod_account]                        # account(s) the group will have access to. Permissions they will have in account are above line
+    DevOpsLead : {
+      principal_name  = "DevOpsLead"                # name of the user or group you wish to have access to the account(s)
+      principal_type  = "GROUP"                             # principal type (user or group) you wish to have access to the account(s)
+      principal_idp   = "INTERNAL"                          # type of Identity Provider you are using. Valid values are "INTERNAL" (using Identity Store) or "EXTERNAL" (using external IdP such as EntraID, Okta, Google, etc.)
+      permission_sets = ["PowerUserAccess"]                 # permissions the user/group will have in the account(s)
+      account_ids     = [var.prod_account, var.uat_account] # account(s) the group will have access to. Permissions they will have in account are above line
     },
     DevOps : {
       principal_name  = "DevOps"
       principal_type  = "GROUP"
       principal_idp   = "INTERNAL"
       permission_sets = ["PowerUserAccess"]
-      account_ids     = [var.prod_account]
+      account_ids     = [var.uat_account]
     },
     Dev : {
       principal_name  = "Dev"
       principal_type  = "GROUP"
       principal_idp   = "INTERNAL"
       permission_sets = ["ReadOnlyAccess"]
-      account_ids     = [var.prod_account]
+      account_ids     = [var.uat_account]
     },
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "prod_account" {
   type = string
 }
 
-variable "dev_account" {
+variable "uat_account" {
   type = string
 }
 


### PR DESCRIPTION
# Summary
Init CI/CD workflow for access-control terraform.
# Details
- Copy terraform-plan & terraform-apply workflow from *terraform-bootstrap*
- Additional steps
  - Checkout *terraform-bootstrap* to reuse the composite actions
> In future, these common actions should be stored in a seperate repository, and should use proper reference.