### PR TITLE
feat: update devops group permission, add administrator

### DIFF
--- a/dev/main.tf
+++ b/dev/main.tf
@@ -137,7 +137,7 @@ module "aws-iam-identity-center" {
       principal_name  = "DevOps"
       principal_type  = "GROUP"
       principal_idp   = "INTERNAL"
-      permission_sets = ["PowerUser"]
+      permission_sets = ["Administrator", "PowerUser"]
       account_ids     = [var.dev_account]
     },
     Dev : {


### PR DESCRIPTION
# Summary
DevOps member need to create IAM users and policies to perform permission testing for terraform pipeline runner. But the poweruser access is not granting them enough permissions
# Details
- Add Adminstrator Permission to DevOps SSO Group
